### PR TITLE
Fix Verba RAG stack startup issues and improve usability

### DIFF
--- a/verba/QUICKSTART.md
+++ b/verba/QUICKSTART.md
@@ -1,0 +1,95 @@
+# Verba RAG Stack - Quick Start Guide
+
+## Prerequisites
+
+Install Flox if you haven't already:
+```bash
+brew install flox
+```
+
+## Starting the Stack
+
+### Step 1: Start All Services
+
+In a terminal window, run:
+```bash
+./start-verba.sh
+```
+
+This will:
+- Activate the Flox environment
+- Install Python packages (first run only, ~2-3 minutes)
+- Start Ollama, Weaviate, and Verba services
+- Keep the terminal session active (press Ctrl+C to stop)
+
+**Important:** Keep this terminal window open while using Verba.
+
+### Step 2: Pull Required Models (First Time Only)
+
+In a **new terminal window**, run:
+```bash
+./pull-models.sh
+```
+
+This will download:
+- `llama3` - The main language model
+- `mxbai-embed-large` - The embedding model for document processing
+
+**Note:** Model downloads can take 5-10 minutes depending on your internet connection.
+
+### Step 3: Access Verba
+
+Open your browser and navigate to:
+- **Verba UI:** http://localhost:8000
+
+## Using Verba
+
+1. **Upload Documents**
+   - Click on the "Documents" section
+   - Upload PDFs, text files, or markdown documents
+   - Wait for processing to complete
+
+2. **Ask Questions**
+   - Use the chat interface to query your documents
+   - Verba will retrieve relevant passages and generate answers
+
+## Stopping the Services
+
+Press `Ctrl+C` in the terminal running `start-verba.sh` to stop all services.
+
+## Troubleshooting
+
+### Services won't start
+- Make sure no other services are using ports 8000, 8080, or 11434
+- Check with: `lsof -i :8000` (repeat for other ports)
+
+### Ollama not responding
+- Wait 30-60 seconds after starting for Ollama to initialize
+- Check status: `curl http://localhost:11434/api/tags`
+
+### Python package errors
+- The environment will auto-install packages on first run
+- If issues persist, clear cache: `rm -rf .flox/cache/python`
+
+### Models not downloading
+- Ensure Ollama is running first (start-verba.sh must be active)
+- Check Ollama logs in the terminal running start-verba.sh
+
+## Manual Commands
+
+If you prefer manual control:
+
+```bash
+# Activate environment and start services
+flox activate --start-services
+
+# In the activated environment, pull models
+ollama pull llama3
+ollama pull mxbai-embed-large
+
+# Check service status
+flox services status
+
+# Stop services
+flox services stop
+```

--- a/verba/manifest.toml
+++ b/verba/manifest.toml
@@ -48,15 +48,17 @@ on-activate = '''
   # Create virtual environment if it doesn't exist
   if [ ! -d "$PYTHON_DIR" ]; then
     echo "Creating Python virtual environment..."
-    gum spin -s globe --title "Creating venv in $PYTHON_DIR..." -- python -m venv "$PYTHON_DIR"
+    python -m venv "$PYTHON_DIR"
   fi
   
   # Install/update Verba package
-  (
-    source "$PYTHON_DIR/bin/activate"
-    echo "Installing/updating Verba package..."
-    gum spin -s monkey --title "Installing/updating Verba..." -- pip install --upgrade "$VERBA_INSTALL_PACKAGE"
-  )
+  if [ -f "$PYTHON_DIR/bin/activate" ]; then
+    (
+      source "$PYTHON_DIR/bin/activate"
+      echo "Installing/updating Verba package..."
+      pip install --upgrade "$VERBA_INSTALL_PACKAGE" 2>/dev/null || pip install "$VERBA_INSTALL_PACKAGE"
+    )
+  fi
   
   # Create data directory if it doesn't exist
   if [ ! -d "$PERSISTENCE_DATA_PATH" ]; then

--- a/verba/pull-models.sh
+++ b/verba/pull-models.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Pull required Ollama models for Verba
+# Run this after starting services with ./start-verba.sh
+
+echo "📥 Pulling required Ollama models..."
+echo ""
+
+# Check if Ollama is running
+if ! curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
+    echo "❌ Error: Ollama is not running."
+    echo "Please start services first with: ./start-verba.sh"
+    exit 1
+fi
+
+echo "Pulling llama3 model (this may take a while)..."
+flox activate -- ollama pull llama3
+
+echo ""
+echo "Pulling mxbai-embed-large model for embeddings..."
+flox activate -- ollama pull mxbai-embed-large
+
+echo ""
+echo "✅ Models pulled successfully!"
+echo ""
+echo "You can now access Verba at: http://localhost:8000"

--- a/verba/start-stack-simple.sh
+++ b/verba/start-stack-simple.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Simple start script that uses Flox services directly
+
+set -e
+
+echo "🚀 Starting Verba RAG Stack..."
+echo ""
+
+# Check if Flox is installed
+if ! command -v flox &> /dev/null; then
+    echo "❌ Error: Flox is not installed."
+    echo "Please install Flox first: https://flox.dev/docs/install"
+    exit 1
+fi
+
+# Start all services using Flox
+echo "📦 Starting all services with Flox..."
+echo "  • Ollama (LLM Server)"
+echo "  • Weaviate (Vector Database)"
+echo "  • Verba (UI)"
+echo ""
+
+# Start services in the background
+flox activate --start-services &
+sleep 2
+
+# Wait for services to start
+echo "⏳ Waiting for services to start..."
+sleep 10
+
+# Check if Ollama is ready
+echo "Checking Ollama status..."
+if flox activate -- curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
+    echo "✅ Ollama is ready!"
+    
+    # Pull required models
+    echo ""
+    echo "📥 Pulling required Ollama models..."
+    flox activate -- ollama pull llama3 || echo "Note: Model may already exist"
+    flox activate -- ollama pull mxbai-embed-large || echo "Note: Model may already exist"
+else
+    echo "⚠️  Ollama may still be starting up. You can pull models manually later with:"
+    echo "  flox activate -- ollama pull llama3"
+    echo "  flox activate -- ollama pull mxbai-embed-large"
+fi
+
+echo ""
+echo "✅ Services are starting!"
+echo ""
+echo "📌 Access points:"
+echo "  • Verba UI: http://localhost:8000"
+echo "  • Weaviate: http://localhost:8080"
+echo "  • Ollama: http://localhost:11434"
+echo ""
+echo "Press Ctrl+C to stop all services"
+echo ""
+
+# Trap Ctrl+C to stop services cleanly
+trap 'echo ""; echo "Stopping services..."; flox services stop; exit' INT
+
+# Keep script running
+while true; do
+    sleep 10
+done

--- a/verba/start-stack.sh
+++ b/verba/start-stack.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Start the complete Verba RAG stack
+# Start the complete Verba RAG stack - all in one terminal
+# This script starts services and pulls models automatically
 
 set -e
 
@@ -9,36 +10,100 @@ echo ""
 # Check if Flox is installed
 if ! command -v flox &> /dev/null; then
     echo "❌ Error: Flox is not installed."
-    echo "Please install Flox first: https://flox.dev/docs/install"
+    echo "Please install Flox first:"
+    echo "  brew install flox"
+    echo "  or"
+    echo "  curl -fsSL https://downloads.flox.dev/by-env/stable/install.sh | sh"
     exit 1
 fi
 
-# Activate Flox environment
-echo "📦 Activating Flox environment..."
-eval "$(flox activate)"
+# Check if we're in the right directory
+if [ ! -f "manifest.toml" ]; then
+    echo "❌ Error: manifest.toml not found."
+    echo "Please run this script from the verba directory."
+    exit 1
+fi
 
-# Pull Ollama models if not already present
-echo ""
-echo "📥 Pulling required Ollama models..."
-ollama pull llama3
-ollama pull mxbai-embed-large
-
-# Start all services
-echo ""
-echo "🔧 Starting services..."
-echo "  • Weaviate (Vector Database)"
+echo "📦 Starting all services..."
 echo "  • Ollama (LLM Server)"
+echo "  • Weaviate (Vector Database)"
 echo "  • Verba (UI)"
 echo ""
+echo "Note: First-time setup will install Python packages (2-3 minutes)"
+echo "      Model downloads will happen after services start (5-10 minutes)"
+echo ""
 
-flox services start
+# Function to check and pull models
+check_and_pull_models() {
+    # Wait for Ollama to be ready
+    echo "⏳ Waiting for Ollama to initialize..."
+    local counter=0
+    local max_tries=20
+    
+    while ! curl -s http://localhost:11434/api/tags > /dev/null 2>&1; do
+        if [ $counter -ge $max_tries ]; then
+            echo "⚠️  Ollama is taking longer than expected."
+            echo "    You can manually pull models later with:"
+            echo "    flox activate -- ollama pull llama3"
+            echo "    flox activate -- ollama pull mxbai-embed-large"
+            return
+        fi
+        echo "  Waiting for Ollama... ($((counter+1))/$max_tries)"
+        sleep 3
+        counter=$((counter+1))
+    done
+    
+    echo "✅ Ollama is ready!"
+    echo ""
+    echo "📥 Checking and pulling required models..."
+    
+    # Check if llama3 exists
+    if ollama list 2>/dev/null | grep -q "llama3"; then
+        echo "  ✓ llama3 model already exists"
+    else
+        echo "  ⬇ Pulling llama3 model (this may take a few minutes)..."
+        ollama pull llama3 || echo "  ⚠️ Failed to pull llama3 - you can retry manually later"
+    fi
+    
+    # Check if mxbai-embed-large exists
+    if ollama list 2>/dev/null | grep -q "mxbai-embed-large"; then
+        echo "  ✓ mxbai-embed-large model already exists"
+    else
+        echo "  ⬇ Pulling mxbai-embed-large model..."
+        ollama pull mxbai-embed-large || echo "  ⚠️ Failed to pull mxbai-embed-large - you can retry manually later"
+    fi
+    
+    echo ""
+    echo "✅ Model setup complete!"
+}
 
-echo ""
-echo "✅ All services started!"
-echo ""
-echo "📌 Access points:"
-echo "  • Verba UI: http://localhost:8000"
-echo "  • Weaviate: http://localhost:8080"
-echo "  • Ollama: http://localhost:11434"
-echo ""
-echo "Press Ctrl+C to stop all services"
+# Export the function so it can be used in the subshell
+export -f check_and_pull_models
+
+# Start services and run model pulling in the activated environment
+exec flox activate --start-services --command "
+    # Run model pulling in background after a delay
+    (sleep 10 && check_and_pull_models) &
+    
+    echo ''
+    echo '════════════════════════════════════════════════════════'
+    echo '✅ Verba RAG Stack is starting!'
+    echo '════════════════════════════════════════════════════════'
+    echo ''
+    echo '📌 Access points (wait ~30 seconds for services to start):'
+    echo '  • Verba UI:  http://localhost:8000'
+    echo '  • Weaviate:  http://localhost:8080'
+    echo '  • Ollama:    http://localhost:11434'
+    echo ''
+    echo '📝 Quick tips:'
+    echo '  • Models will download automatically in the background'
+    echo '  • Upload documents in Verba UI to build your knowledge base'
+    echo '  • Use the chat interface to query your documents'
+    echo ''
+    echo 'Press Ctrl+C to stop all services'
+    echo '────────────────────────────────────────────────────────'
+    echo ''
+    
+    # Keep the session alive
+    exec bash
+"

--- a/verba/start-verba.sh
+++ b/verba/start-verba.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Start the Verba RAG stack using Flox
+# This script properly activates the Flox environment and starts all services
+
+set -e
+
+echo "🚀 Starting Verba RAG Stack..."
+echo ""
+
+# Check if Flox is installed
+if ! command -v flox &> /dev/null; then
+    echo "❌ Error: Flox is not installed."
+    echo "Please install Flox first:"
+    echo "  brew install flox"
+    echo "  or"
+    echo "  curl -fsSL https://downloads.flox.dev/by-env/stable/install.sh | sh"
+    exit 1
+fi
+
+# Check if we're in the right directory
+if [ ! -f "manifest.toml" ]; then
+    echo "❌ Error: manifest.toml not found."
+    echo "Please run this script from the verba directory."
+    exit 1
+fi
+
+echo "📦 Activating Flox environment and starting services..."
+echo ""
+echo "This will start:"
+echo "  • Ollama (LLM Server) on http://localhost:11434"
+echo "  • Weaviate (Vector Database) on http://localhost:8080"  
+echo "  • Verba (UI) on http://localhost:8000"
+echo ""
+echo "Note: First-time setup will install Python packages, which may take a few minutes."
+echo ""
+
+# Activate the environment and start services
+# This command will:
+# 1. Activate the Flox environment
+# 2. Install/update Python packages if needed (on first run)
+# 3. Start all services defined in manifest.toml
+# 4. Keep the session active
+echo "Starting services (this may take a moment)..."
+exec flox activate --start-services


### PR DESCRIPTION
- Fixed ollama command not found error in start-stack.sh
- Removed dependency on gum for non-TTY environments in manifest.toml
- Created single-terminal solution for starting the entire stack
- Added automatic model pulling after services start
- Added helper scripts for better user experience:
  - QUICKSTART.md: Step-by-step guide for new users
  - pull-models.sh: Separate script for model downloads
  - start-verba.sh: Alternative simple startup script
  - start-stack-simple.sh: Simplified version for testing
- Improved error handling and user feedback throughout

The main issue was that the original script tried to use ollama commands directly after eval "$(flox activate)", which doesn't properly set up the environment in a script context. The new approach uses "flox activate --start-services --command" to run everything in the properly activated environment.

🤖 Generated with [Claude Code](https://claude.ai/code)