### PR TITLE
Fix flox command syntax in Verba start script

### DIFF
--- a/verba/start-stack.sh
+++ b/verba/start-stack.sh
@@ -81,7 +81,7 @@ check_and_pull_models() {
 export -f check_and_pull_models
 
 # Start services and run model pulling in the activated environment
-exec flox activate --start-services --command "
+exec flox activate --start-services -- bash -c "
     # Run model pulling in background after a delay
     (sleep 10 && check_and_pull_models) &
     


### PR DESCRIPTION
## Summary
- Fixed incorrect `--command` flag in flox activate command
- Changed to proper `-- bash -c` syntax to resolve startup error
- Resolves error: "expected `<cmd>` to be on the right side of `--`"

## Test plan
- [ ] Run `./start-stack.sh` in the verba directory
- [ ] Verify no syntax errors appear
- [ ] Confirm services start successfully

🤖 Generated with [Claude Code](https://claude.ai/code)